### PR TITLE
feat(download): normalize slov-lex URLs to static portal format

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,6 @@ slovak-law-word-count ./downloads --download-url "https://www.slov-lex.sk/pravne
 
 # To Do
 
-- fix `download_fun.py`: function seems to work, but slov-lex.sk started to block it
-    - currently gives error: `HTTPSConnectionPool(host='www.slov-lex.sk', port=443): Max retries exceeded with url: /pravne-predpisy/SK/ZZ/1992/460/20230701 (Caused by SSLError(SSLError(1, '[SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:1006)')))`
-    - but `curl https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/1992/460/20230701` as well as `download_links_from_table('https://example.org/', '../Constitution')` works
-    - you can also download all legal texts (11 GB, zip archive) from [slov-lex.sk](https://www.slov-lex.sk/archiv-zbierky-zakonov)
 - add additional metrics:
     - longest (shortest) sentences from `s_sentences()`
     - longest (shortest) words from `s_readability()`

--- a/src/slovak_law_word_count/download_fun.py
+++ b/src/slovak_law_word_count/download_fun.py
@@ -30,11 +30,13 @@ Usage:
 
 import logging
 from pathlib import Path
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin, urlparse, urlunparse
 
 import requests
 from bs4 import BeautifulSoup
 from bs4.element import Tag
+
+from .normalize import SlovLexStaticUrlBuilder
 
 # Set the maximum supported TLS version to TLS 1.2 # slov-lex.sk does not support TLS 1.3
 # ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
@@ -60,8 +62,15 @@ session.headers.update(
 
 MIN_ROW_COLUMNS_FOR_LINK = 2
 LINK_COLUMN_INDEX = 1
+MIN_STANDARD_PATH_PARTS = 4
+STANDARD_PATH_WITH_DATE_PARTS = 5
+STANDARD_DATE_INDEX = 4
+DATE_LENGTH = 8
+STANDARD_URL_PREFIX = "/ezbierky/pravne-predpisy/"
+STATIC_URL_PREFIX = "/static/"
 PathLike = str | Path
 logger = logging.getLogger(__name__)
+static_url_builder = SlovLexStaticUrlBuilder()
 
 
 def _get_headers(accept: str) -> dict:
@@ -76,6 +85,108 @@ def _get_headers(accept: str) -> dict:
     }
 
 
+def _remove_query_and_fragment(url: str) -> str:
+    """Return URL without query string and fragment."""
+    parsed = urlparse(url)
+    return urlunparse(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path,
+            "",
+            "",
+            "",
+        ),
+    )
+
+
+def _normalize_static_url(url: str) -> str:
+    """Normalize static.slov-lex URL and remove the optional version query."""
+    parsed = urlparse(url)
+    path = parsed.path.rstrip("/")
+    tail = path[len(STATIC_URL_PREFIX) :].strip("/")
+    path_parts = tail.split("/")
+    if len(path_parts) >= STANDARD_PATH_WITH_DATE_PARTS:
+        date_part = path_parts[STANDARD_DATE_INDEX]
+        date_part = date_part.removesuffix(static_url_builder.end)
+        try:
+            return static_url_builder.build(
+                country=path_parts[0],
+                collection=path_parts[1],
+                year=path_parts[2],
+                law_number=path_parts[3],
+                date=date_part,
+            )
+        except ValueError:
+            logger.warning("Invalid static URL components: %s", url)
+    return urlunparse(("https", "static.slov-lex.sk", path, "", "", ""))
+
+
+def _resolve_standard_url_to_static(url: str) -> str | None:
+    """Follow redirects to obtain static URL for standard links without date."""
+    try:
+        response = session.get(url, allow_redirects=True, timeout=10)
+        response.raise_for_status()
+    except requests.exceptions.RequestException:
+        logger.exception("Failed to resolve standard URL to static URL")
+        return None
+
+    resolved_url = _remove_query_and_fragment(response.url)
+    parsed_resolved = urlparse(resolved_url)
+    if (
+        parsed_resolved.netloc == "static.slov-lex.sk"
+        and parsed_resolved.path.startswith(STATIC_URL_PREFIX)
+    ):
+        return _normalize_static_url(resolved_url)
+    return None
+
+
+# TODO: simplify ulr normalization process,
+#   this works but the code is not as readable as it could
+def normalize_slov_lex_url(url: str) -> str:
+    """Normalize slov-lex document URLs to static portal format when possible."""
+    normalized_input = url.strip()
+    parsed = urlparse(normalized_input)
+    host = parsed.netloc.lower()
+    path = parsed.path.rstrip("/")
+
+    if host == "static.slov-lex.sk" and path.startswith(STATIC_URL_PREFIX):
+        return _normalize_static_url(normalized_input)
+
+    if host != "www.slov-lex.sk" or not path.startswith(STANDARD_URL_PREFIX):
+        return _remove_query_and_fragment(normalized_input)
+
+    tail = path[len(STANDARD_URL_PREFIX) :].strip("/")
+    path_parts = tail.split("/")
+    if len(path_parts) < MIN_STANDARD_PATH_PARTS:
+        return _remove_query_and_fragment(normalized_input)
+
+    # Standard URLs with explicit date can be rewritten locally.
+    if (
+        len(path_parts) >= STANDARD_PATH_WITH_DATE_PARTS
+        and path_parts[STANDARD_DATE_INDEX].isdigit()
+        and len(path_parts[STANDARD_DATE_INDEX]) == DATE_LENGTH
+    ):
+        try:
+            return static_url_builder.build(
+                country=path_parts[0],
+                collection=path_parts[1],
+                year=path_parts[2],
+                law_number=path_parts[3],
+                date=path_parts[STANDARD_DATE_INDEX],
+            )
+        except ValueError:
+            logger.warning("Invalid standard URL components: %s", normalized_input)
+            return _remove_query_and_fragment(normalized_input)
+
+    # For legacy URLs without date, resolve the redirect once.
+    resolved = _resolve_standard_url_to_static(normalized_input)
+    if resolved:
+        return resolved
+
+    return _remove_query_and_fragment(normalized_input)
+
+
 def download_links_from_table(url: str, save_path: PathLike) -> None:
     """Download links from the specified table on slov-lex.sk.
 
@@ -84,7 +195,7 @@ def download_links_from_table(url: str, save_path: PathLike) -> None:
         save_path (str): The local directory where downloaded files will be saved.
 
     """
-    url = url.strip()
+    url = normalize_slov_lex_url(url)
 
     try:
         response = session.get(

--- a/src/slovak_law_word_count/normalize.py
+++ b/src/slovak_law_word_count/normalize.py
@@ -1,0 +1,71 @@
+"""Utilities for building and validating slov-lex static URLs."""
+
+from dataclasses import dataclass
+from urllib.parse import urlunparse
+
+DATE_LENGTH = 8
+YEAR_LENGTH = 4
+
+
+@dataclass(frozen=True)
+class SlovLexStaticUrlBuilder:
+    """Build static slov-lex URLs with fixed host, path prefix, and suffix."""
+
+    host: str = "static.slov-lex.sk"
+    path_start: str = "/static"
+    end: str = ".portal"
+    scheme: str = "https"
+
+    def _validate_country(self, country: str) -> None:
+        if not country.isalpha() or not country.isupper():
+            msg = "country must contain uppercase letters only (example: SK)"
+            raise ValueError(msg)
+
+    def _validate_collection(self, collection: str) -> None:
+        if not collection.isalpha() or not collection.isupper():
+            msg = "collection must contain uppercase letters only (example: ZZ)"
+            raise ValueError(msg)
+
+    def _validate_year(self, year: str) -> None:
+        if not (year.isdigit() and len(year) == YEAR_LENGTH):
+            msg = "year must be exactly 4 digits"
+            raise ValueError(msg)
+
+    def _validate_law_number(self, law_number: str) -> None:
+        if not law_number.isdigit():
+            msg = "law_number must contain digits only"
+            raise ValueError(msg)
+
+    def _validate_date(self, date: str) -> None:
+        if not (date.isdigit() and len(date) == DATE_LENGTH):
+            msg = "date must be exactly 8 digits in YYYYMMDD format"
+            raise ValueError(msg)
+
+    def _validate_version(self, version: str | None) -> None:
+        if version is not None and not version.isdigit():
+            msg = "version must contain digits only"
+            raise ValueError(msg)
+
+    def build(
+        self,
+        country: str,
+        collection: str,
+        year: str,
+        law_number: str,
+        date: str,
+        version: str | None = None,
+    ) -> str:
+        """Build a canonical static URL for slov-lex law snapshots."""
+        self._validate_country(country)
+        self._validate_collection(collection)
+        self._validate_year(year)
+        self._validate_law_number(law_number)
+        self._validate_date(date)
+        self._validate_version(version)
+
+        path = (
+            f"{self.path_start.rstrip('/')}/{country}/{collection}/"
+            f"{year}/{law_number}/{date}{self.end}"
+        )
+        query = f"version={version}" if version else ""
+        return urlunparse((self.scheme, self.host, path, "", query, ""))

--- a/src/slovak_law_word_count/stanza_analysis.py
+++ b/src/slovak_law_word_count/stanza_analysis.py
@@ -132,8 +132,9 @@ def s_analysis(
 
     Example:
     ```python
-    output = s_analysis("/path/to/documents_folder",
-    stop_words=["and", "the"], nazov_zakonu="Zakon123")
+    output = s_analysis(
+        "/path/to/documents_folder", stop_words=["and", "the"], nazov_zakonu="Zakon123"
+    )
     ```
 
     Metrics are saved in CSV files, and bar charts and word clouds are generated


### PR DESCRIPTION
- Add robust URL normalization in `download_fun.py` for `www.slov-lex.sk/ezbierky/...` and `static.slov-lex.sk/static/...` links.
- Introduce helpers to strip query/fragment, normalize static paths, and resolve legacy standard URLs via redirects.
- Use `SlovLexStaticUrlBuilder` to validate/build canonical static `.portal` URLs.
- Apply normalization in `download_links_from_table` before requesting content.
- Update docs/chore: remove outdated README TODO about slov-lex blocking; reflow example formatting in `stanza_analysis.py` docstring.